### PR TITLE
grammar correction tutorial 02

### DIFF
--- a/notes/02_online-pca/1_oja.tex
+++ b/notes/02_online-pca/1_oja.tex
@@ -22,8 +22,7 @@ Modify the update rule such that
 \begin{itemize}
 \item it contains an 
 \emph{implicit normalization} to prevent divergence and 
-still 
-\item $\vec w$ converges to the direction of the first PC.
+\item $\vec w$ still converges to the direction of the first PC.
 \end{itemize}
 
 \question{How?}


### PR DESCRIPTION
the formatting in the notes works better by putting 'still' with the second item